### PR TITLE
Update class name extraction to handle "-[digit]" suffixes

### DIFF
--- a/src/convert_annotations.py
+++ b/src/convert_annotations.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from glob import glob
 import argparse
-
+import re
 
 def get_class_names_logodet(path):
     classes = {}
@@ -117,7 +117,7 @@ def extract_info_from_xml(xml_file):
             bbox = {}
             for subelem in elem:
                 if subelem.tag == "name":
-                    bbox["class"] = subelem.text
+                    bbox["class"] = re.split(r'-\d+', subelem.text)[0]
                     
                 elif subelem.tag == "bndbox":
                     for subsubelem in subelem:


### PR DESCRIPTION
Previously, the class name was taken directly from the "name" tag, which caused problems when class names had numeric suffixes (e.g., "yuyue-3"). 
This made it difficult to work with just the base class name.

The code now uses a regex pattern to remove the "-[digit]" part, ensuring only the base class name is extracted. 
This makes it easier to process annotations with numeric suffixes in class names.